### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,3 @@ flatpak run io.github.lainsce.Emulsion
 git clone git@github.com:flathub/io.github.lainsce.Emulsion.git
 flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --install io.github.lainsce.Emulsion.json
 ```
-
----
-
-**Technologies**: GTK, Vala, libhelium

--- a/io.github.lainsce.Emulsion.json
+++ b/io.github.lainsce.Emulsion.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.lainsce.Emulsion",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.lainsce.Emulsion",
     "finish-args" : [
@@ -12,15 +12,9 @@
     ],
     "cleanup" : [
         "/include",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "/share/vala",
-        "*.la",
-        "*.a"
+        "/share/vala"
     ],
     "modules" : [
         {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size
- Drop the technologies section from the README file to stop interfering with search results.